### PR TITLE
rpki updates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,14 +100,20 @@ services:
       - net.ipv4.tcp_keepalive_time=180
     ports:
       - 9005:9005
-      - 8080:8080
+
     volumes:
       - ${OBMP_DATA_ROOT}/config:/config
     environment:
       - MEM=4                                           # Set memory to at least 2GB but ideally 4GB
       - KAFKA_FQDN=obmp-kafka:29092
+      - RPKI_URL=https://rpki.cloudflare.com/rpki.json  # define the URL to retrieve json endoed RPKI data
+      - RPKI_PASS=None
+      - RPKI_USER=None
       - ENABLE_RPKI=1                                   # 1 enables, 0 disables RPKI sync
       - ENABLE_IRR=1                                    # 1 enables, 0 disables IRR sync
+      - POSTGRES_REPORT_WINDOW='8 minute'               # default POSTGRESS window to select when building
+                                                        # summary tables. For deployments that absorb large
+                                                        # bursts increase the value, ex 60 minute
       - POSTGRES_PASSWORD=openbmp
       - POSTGRES_USER=openbmp
       - POSTGRES_DB=openbmp

--- a/psql-app/Dockerfile
+++ b/psql-app/Dockerfile
@@ -62,9 +62,6 @@ VOLUME ["/config"]
 # Consumer JMX console
 EXPOSE 9005
 
-# RPKI Validator port
-EXPOSE 8080
-
 #----------------------------------
 # Define working directory.
 WORKDIR /tmp
@@ -85,23 +82,11 @@ RUN cd /tmp && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
 
 RUN pip install ipaddr pykafka
 
+RUN pip3 install urllib3 requests
+
 # Cleanup
 RUN apt-get autoremove && apt-get clean
 
-#----------------------------------
-# Install RPKI validator (https://github.com/RIPE-NCC/rpki-validator-3/wiki)
-RUN mkdir /usr/local/rpki && cd /tmp \
-    && wget https://ftp.ripe.net/tools/rpki/validator3/prod/generic/rpki-validator-3-latest-dist.tar.gz \
-    && tar xzf rpki-validator-3-latest-dist.tar.gz \
-    && cd rpki-validator-*/ \
-    && mv * /usr/local/rpki/ \
-    && rm -rf /tmp/rpki-* \
-    && cd /usr/local/rpki \
-    && sed -i -r 's/.*server.address=.*/server.address=0.0.0.0/' /usr/local/rpki/conf/application.properties \
-    && sed -i -r 's/jvm.mem.maximum=.*/jvm.mem.maximum=2g/' /usr/local/rpki/conf/application.properties
-
-
-#----------------------------------
 # Define default command.
 CMD ["/usr/sbin/run"]
 

--- a/psql-app/scripts/run
+++ b/psql-app/scripts/run
@@ -108,15 +108,10 @@ enable_rpki() {
 MAILTO=""
 
 # Update RPKI
-31 */2 * * *	root  . /usr/local/openbmp/pg_profile && /usr/local/openbmp/rpki_validator.py -u $PGUSER -p $PGPASSWORD -s 127.0.0.1:8080 $PGHOST
+31 */2 * * *	root  . /usr/local/openbmp/pg_profile && /usr/local/openbmp/rpki_validator.py -u $PGUSER -p $PGPASSWORD -s $RPKI_URL --rpkipassword $RPKI_PASS --rpkiuser $RPKI_USER $PGHOST
 
 SETVAR
 
-    echo "===> Downloading and Installing ARIN TAL"
-    wget -q https://www.arin.net/resources/manage/rpki/arin-rfc7730.tal -O /usr/local/rpki/preconfigured-tals/arin.tal
-
-    # start RPKI validator
-    /usr/local/rpki/rpki-validator-3.sh > /var/log/rpki-validator.log &
 }
 
 # -----------------------------------------------
@@ -149,7 +144,7 @@ MAILTO=""
 6 */2 * * *	root  . /usr/local/openbmp/pg_profile && /usr/local/openbmp/gen_whois_asn.py -u $PGUSER -p $PGPASSWORD $PGHOST >> /var/log/asn_load.log
 
 # Update aggregation table stats
-*/3 * * * *  root   . /usr/local/openbmp/pg_profile && psql -c "select update_chg_stats('8 minute')"
+*/3 * * * *  root   . /usr/local/openbmp/pg_profile && psql -c "select update_chg_stats($POSTGRES_REPORT_WINDOW)"
 
 # Update peer rib counts
 */15 * * * *	root   . /usr/local/openbmp/pg_profile && psql -c "select update_peer_rib_counts()"


### PR DESCRIPTION
Changes so that the RPKI data can come from an external source. By default it can pull the RPKI data from cloudflare, or a local RPKI validator (ripe, nlnetlabs, cloudflare) can be used.

Also added a variable so that the summary table generation can be changed from the default of 8 minutes to something larger if very large BGP updates are coming in, and it is taking longer than 8 minutes for the data to get into the database.