### PR TITLE
fixing two typos in psql-app/scripts/run

### DIFF
--- a/psql-app/scripts/run
+++ b/psql-app/scripts/run
@@ -10,7 +10,7 @@
 export POSTGRES_USER=${POSTGRES_USER:="openbmp"}
 export POSTGRES_PASSWORD=${POSTGRES_PASSWORD:="openbmp"}
 export POSTGRES_HOST=${POSTGRES_HOST:="127.0.0.1"}
-exprot POSTGRES_PORT=${POSTGRES_PORT:="5432"}
+export POSTGRES_PORT=${POSTGRES_PORT:="5432"}
 export POSTGRES_DB=${POSTGRES_DB:="openbmp"}
 export MEM=${MEM:="1"}                          # mem in gigabytes
 export PGCONNECT_TIMEOUT=15
@@ -157,7 +157,7 @@ MAILTO=""
 
 # Purge time series data that is older than desired retention
 0 * */3 * *     root  . /usr/local/openbmp/pg_profile && psql -c "SELECT drop_chunks('peer_event_log', interval '1 year');"
-1 * */3 * *     root  . /usr/local/openbmp/pg_profile && psql -c "SELECT drop_chunks('stat_reports', 'interval 4 weeks');"
+1 * */3 * *     root  . /usr/local/openbmp/pg_profile && psql -c "SELECT drop_chunks('stat_reports', interval '4 weeks');"
 2 * */3 * *     root  . /usr/local/openbmp/pg_profile && psql -c "SELECT drop_chunks('ip_rib_log', interval '4 weeks');"
 3 * */3 * *     root  . /usr/local/openbmp/pg_profile && psql -c "SELECT drop_chunks('alerts', interval '6 months');"
 4 * */3 * *     root  . /usr/local/openbmp/pg_profile && psql -c "SELECT drop_chunks('ls_nodes_log', interval '4 months');"


### PR DESCRIPTION
There are two errors in the file, one where "export" was spelled wrong, and the second the crontab entry for stat_report has the quote in the wrong spot