### PR TITLE
feat: add pg_cron extension for cron jobs

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -14,6 +14,8 @@
 
 FROM timescale/timescaledb:2.5.1-pg14
 
+ENV PG_CRON_VERSION 1.3.0
+
 # Current/working dir
 VOLUME ["/ws"]
 WORKDIR /ws
@@ -25,7 +27,7 @@ VOLUME ["/var/lib/postgresql/ts"]
 
 
 RUN apk update \
-    && apk add openssl \
+    && apk add --no-cache --virtual .build-deps build-base ca-certificates clang-dev llvm12 openssl\
     && openssl req -x509 -newkey rsa:4096 -nodes -subj "/C=US/ST=CA/L=Seattle/O=OpenBMP/CN=localhost"  \
         -keyout /psql_server.key -out /psql_server.crt -days 2048 \
     && chown postgres /psql_server.* \
@@ -37,12 +39,18 @@ RUN apk update \
     && sed -i -e "s/^\#*max_wal_size.*=.*/max_wal_size = 10GB/" /usr/local/share/postgresql/postgresql.conf.sample \
     && sed -i -e "s/^\#*ssl[ ]*=.*/ssl = on/" /usr/local/share/postgresql/postgresql.conf.sample \
     && sed -i -e "s/^\#*ssl_cert_file.*=.*/ssl_cert_file = \'\/psql_server.crt\'/" /usr/local/share/postgresql/postgresql.conf.sample \
-    && sed -i -e "s/^\#*ssl_key_file.*=.*/ssl_key_file = \'\/psql_server.key\'/" /usr/local/share/postgresql/postgresql.conf.sample
+    && sed -i -e "s/^\#*ssl_key_file.*=.*/ssl_key_file = \'\/psql_server.key\'/" /usr/local/share/postgresql/postgresql.conf.sample \
+    && sed -i -e "s/^shared_preload_libraries.*/shared_preload_libraries = 'timescaledb,pg_cron'/g" /usr/local/share/postgresql/postgresql.conf.sample
 
-# Init timesries location
-RUN echo 'mkdir -p /var/lib/postgresql/ts/data' > /docker-entrypoint-initdb.d/0_obmp_init.sh \
-    && echo 'chmod 0700 /var/lib/postgresql/ts/data' >> /docker-entrypoint-initdb.d/0_obmp_init.sh \
-    && echo 'psql -U $POSTGRES_USER -c "CREATE TABLESPACE timeseries LOCATION '\''/var/lib/postgresql/ts/data'\'';" $POSTGRES_DB' >> /docker-entrypoint-initdb.d/0_obmp_init.sh
+## Install pg_cron
+RUN wget -O /ws/pg_cron.tgz https://github.com/citusdata/pg_cron/archive/v$PG_CRON_VERSION.tar.gz
+RUN tar xvzf /ws/pg_cron.tgz && cd /ws/pg_cron-1.3.0/ \ 
+    && sed -i.bak -e 's/-Werror//g' Makefile \
+    && sed -i.bak -e 's/-Wno-implicit-fallthrough//g' Makefile \
+    && make && make install \
+    && cd .. && rm -rf pg_cron.tgz && rm -rf pg_cron-* \
+    && apk del .build-deps
 
-
-
+ADD --chmod=755 scripts/0_obmp_init.sh /docker-entrypoint-initdb.d/0_obmp_init.sh
+## providing db name for cron metadata tables
+RUN echo "cron.database_name = 'openbmp'" >> /usr/local/share/postgresql/postgresql.conf.sample

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -43,8 +43,8 @@ RUN apk update \
     && sed -i -e "s/^shared_preload_libraries.*/shared_preload_libraries = 'timescaledb,pg_cron'/g" /usr/local/share/postgresql/postgresql.conf.sample
 
 ## Install pg_cron
-RUN wget -O /ws/pg_cron.tgz https://github.com/citusdata/pg_cron/archive/v$PG_CRON_VERSION.tar.gz
-RUN tar xvzf /ws/pg_cron.tgz && cd /ws/pg_cron-1.3.0/ \ 
+RUN wget -O /ws/pg_cron.tgz https://github.com/citusdata/pg_cron/archive/v$PG_CRON_VERSION.tar.gz \
+    && tar xvzf /ws/pg_cron.tgz && cd /ws/pg_cron-1.3.0/ \ 
     && sed -i.bak -e 's/-Werror//g' Makefile \
     && sed -i.bak -e 's/-Wno-implicit-fallthrough//g' Makefile \
     && make && make install \

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -3,7 +3,7 @@
 #  Copyright (c) 2021-2022 Cisco Systems, Inc. and others.  All rights reserved.
 #
 #  Build:
-#       docker build --platform linux/amd64 -t openbmp/postgres:2.1.0 .
+#        DOCKER_BUILDKIT=1 docker build --platform linux/amd64 -t openbmp/postgres:2.1.0 .
 #
 #  Run:
 #       docker run --rm -it -p 5432:5432 \
@@ -11,6 +11,29 @@
 #              -e POSTGRES_USER=openbmp \
 #              -e POSTGRES_DB=openbmp \
 #              openbmp/postgres:2.1.0
+
+# -----------------------------------------------
+# stage: Build
+# -----------------------------------------------
+FROM timescale/timescaledb:2.5.1-pg14 AS build
+
+ENV PG_CRON_VERSION 1.3.0
+
+WORKDIR /ws
+
+RUN apk update \
+    && apk add --no-cache --virtual .build-deps build-base ca-certificates clang-dev llvm12 openssl
+
+## Install pg_cron
+RUN wget -O pg_cron.tgz https://github.com/citusdata/pg_cron/archive/v$PG_CRON_VERSION.tar.gz \
+    && tar xvzf pg_cron.tgz && cd pg_cron-$PG_CRON_VERSION/ \ 
+    && sed -i.bak -e 's/-Werror//g' Makefile \
+    && sed -i.bak -e 's/-Wno-implicit-fallthrough//g' Makefile \
+    && make
+
+# -----------------------------------------------
+# stage: Final container
+# -----------------------------------------------
 
 FROM timescale/timescaledb:2.5.1-pg14
 
@@ -27,7 +50,7 @@ VOLUME ["/var/lib/postgresql/ts"]
 
 
 RUN apk update \
-    && apk add --no-cache --virtual .build-deps build-base ca-certificates clang-dev llvm12 openssl\
+    && apk add openssl\
     && openssl req -x509 -newkey rsa:4096 -nodes -subj "/C=US/ST=CA/L=Seattle/O=OpenBMP/CN=localhost"  \
         -keyout /psql_server.key -out /psql_server.crt -days 2048 \
     && chown postgres /psql_server.* \
@@ -42,14 +65,12 @@ RUN apk update \
     && sed -i -e "s/^\#*ssl_key_file.*=.*/ssl_key_file = \'\/psql_server.key\'/" /usr/local/share/postgresql/postgresql.conf.sample \
     && sed -i -e "s/^shared_preload_libraries.*/shared_preload_libraries = 'timescaledb,pg_cron'/g" /usr/local/share/postgresql/postgresql.conf.sample
 
-## Install pg_cron
-RUN wget -O /ws/pg_cron.tgz https://github.com/citusdata/pg_cron/archive/v$PG_CRON_VERSION.tar.gz \
-    && tar xvzf /ws/pg_cron.tgz && cd /ws/pg_cron-1.3.0/ \ 
-    && sed -i.bak -e 's/-Werror//g' Makefile \
-    && sed -i.bak -e 's/-Wno-implicit-fallthrough//g' Makefile \
-    && make && make install \
-    && cd .. && rm -rf pg_cron.tgz && rm -rf pg_cron-* \
-    && apk del .build-deps
+COPY --chmod=755 --from=build /ws/pg_cron-$PG_CRON_VERSION/pg_cron.so /usr/local/lib/postgresql/pg_cron.so
+COPY --chmod=644 --from=build /ws/pg_cron-$PG_CRON_VERSION/pg_cron.control /usr/local/share/postgresql/extension/pg_cron.control
+COPY --chmod=644 --from=build /ws/pg_cron-$PG_CRON_VERSION/pg_cron--1.0--1.1.sql /usr/local/share/postgresql/extension/pg_cron--1.0--1.1.sql
+COPY --chmod=644 --from=build /ws/pg_cron-$PG_CRON_VERSION/pg_cron--1.1--1.2.sql /usr/local/share/postgresql/extension/pg_cron--1.1--1.2.sql
+COPY --chmod=644 --from=build /ws/pg_cron-$PG_CRON_VERSION/pg_cron--1.2--1.3.sql /usr/local/share/postgresql/extension/pg_cron--1.2--1.3.sql
+COPY --chmod=644 --from=build /ws/pg_cron-$PG_CRON_VERSION/pg_cron--1.0.sql /usr/local/share/postgresql/extension/pg_cron--1.0.sql
 
 ADD --chmod=755 scripts/0_obmp_init.sh /docker-entrypoint-initdb.d/0_obmp_init.sh
 ## providing db name for cron metadata tables

--- a/postgres/scripts/0_obmp_init.sh
+++ b/postgres/scripts/0_obmp_init.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# postgres: Init script
+#
+#  Copyright (c) 2021 Cisco Systems, Inc. and Tim Evens.  All rights reserved.
+#
+
+
+# Init timesries location
+mkdir -p /var/lib/postgresql/ts/data
+chmod 0700 /var/lib/postgresql/ts/data
+psql -U $POSTGRES_USER -c "CREATE TABLESPACE timeseries LOCATION '/var/lib/postgresql/ts/data';" $POSTGRES_DB
+
+# Config pg cron to database schema
+psql -U $POSTGRES_USER -c "CREATE EXTENSION pg_cron;" $POSTGRES_DB
+psql -U $POSTGRES_USER -c "GRANT USAGE ON SCHEMA cron TO $POSTGRES_USER;" $POSTGRES_DB


### PR DESCRIPTION
This PR adds the pg_cron extension to schedule cron jobs in postgres db itself. 

This also hardcoded the metadata table name as `openbmp` for `pg_cron`